### PR TITLE
Fixes the PREG_REPLACE_EVAL usage vulnerability

### DIFF
--- a/lib/rtp-init.php
+++ b/lib/rtp-init.php
@@ -246,7 +246,7 @@ function rtp_general_sanitize_option(){
             $value = untrailingslashit( $value );
     
     /* Hack for serialized data containing URLs http://www.php.net/manual/en/function.unserialize.php#107886 */
-    $value = preg_replace( '!s:(\d+):"(.*?)";!se', "'s:'.strlen('$2').':\"$2\";'", $value );
+    $value = preg_replace_callback( '!s:(\d+):"(.*?)";!s', function ($matches) { return "'s:'.strlen('$2').':\"$2\";'"; }, $value );
     
     return apply_filters( 'option_' . $option, maybe_unserialize( $value ) );
 }


### PR DESCRIPTION
Usage of e in preg_replace is deprecated due to security vulnerabilities, in place of that preg_replace_callback can be used
http://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
