### PR TITLE
preg_replace warning solution correction

### DIFF
--- a/lib/rtp-init.php
+++ b/lib/rtp-init.php
@@ -239,7 +239,7 @@ function rtp_general_sanitize_option(){
             $value = untrailingslashit( $value );
     
     /* Hack for serialized data containing URLs http://www.php.net/manual/en/function.unserialize.php#107886 */
-    $value = preg_replace_callback( '!s:(\d+):"(.*?)";!s', function ( $matches ) { return "'s:'.strlen('$2').':\"$2\";'"; }, $value );
+    $value = preg_replace( '!s:(\d+):"(.*?)";!s', "'s:'.strlen('$2').':\"$2\";'" , $value );
     
     return apply_filters( 'option_' . $option, maybe_unserialize( $value ) );
 }


### PR DESCRIPTION
Calling preg_replace_callback was not the solution to the preg_replace warning, we only needed to change "!se" to "!s" in the regular expression for resolving the Warning that PHP was generating.
