### PR TITLE
Default menu hooked twice

### DIFF
--- a/lib/rtp-default-functions.php
+++ b/lib/rtp-default-functions.php
@@ -150,7 +150,6 @@ function rtp_default_nav_menu() {
         }
     echo '</nav>';
 }
-add_action('rtp_hook_after_header','rtp_default_nav_menu'); // Adds default nav menu after #header
 
 add_action ( 'rtp_hook_after_header', 'rtp_default_nav_menu' ); // Adds default nav menu after #header
 


### PR DESCRIPTION
Primary navigation Menu is hooked twice on 'rtp_hook_after_header'
