### PR TITLE
Added "npm-debug.log" entry to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .scss-cache/
 scss/.sass-cache/
 node_modules
+npm-debug.log


### PR DESCRIPTION
If npm install command getting failed it create npm-debug.log file in a theme root.
This file should not push to repository.
