### PR TITLE
fixed warning $color argument for single-box-shadow

### DIFF
--- a/assets/rtpanel/scss/_mobile-menu.scss
+++ b/assets/rtpanel/scss/_mobile-menu.scss
@@ -24,7 +24,7 @@ $sidr-text-color: $white;
     /* Theme Settings */
     background: $sidr-background; color: $sidr-text-color; font-family: $sidr-font-family; font-size: $sidr-font-size;
 
-    @include single-box-shadow($sidr-background-shadow-color, 0, 0, 5px, 5px, inset);
+    @include single-box-shadow(0, 0, 5px, 5px, $sidr-background-shadow-color, inset);
 
     ul {
         display: block;
@@ -44,7 +44,7 @@ $sidr-text-color: $white;
 				&.sidr-class-current-menu-item { 
 				border-top: none; line-height: 49px;
 				& > a, & > span {
-					@include single-box-shadow($sidr-background-shadow-color, 0, 0, 15px, 3px, inset);
+					@include single-box-shadow(0, 0, 15px, 3px, $sidr-background-shadow-color, inset);
 				}
             }
 
@@ -62,7 +62,7 @@ $sidr-text-color: $white;
                         border-top: none; line-height: 41px;
 
                         & > a, & > span {
-                            @include single-box-shadow($sidr-background-shadow-color, 0, 0, 15px, 3px, inset);
+                            @include single-box-shadow(0, 0, 15px, 3px, $sidr-background-shadow-color, inset);
                         }
                     }
 


### PR DESCRIPTION
WARNING: The $color argument for single-box-shadow is now the 5th argument instead of the 1st.
         on line 58 of /var/lib/gems/1.9.1/gems/compass-core-1.1.0.alpha.3/stylesheets/compass/css3/_box-shadow.scss, in `single-box-shadow'