### PR TITLE
Correct class name .current_page_ancestor to .current-page-ancestor

### DIFF
--- a/assets/rtpanel/scss/_nav.scss
+++ b/assets/rtpanel/scss/_nav.scss
@@ -88,7 +88,7 @@ $menu-spacing: rem-calc(12 30);
 	}
 
 	// Current Menu Style
-	.current-menu-item, .current_page_ancestor, .current_page_item {
+	.current-menu-item, .current-page-ancestor, .current_page_item {
 		& > a { @include rtp-active-menu(); }
 	}
 }


### PR DESCRIPTION
In nav menu active ancestor has class name .current-page-ancestor.
